### PR TITLE
added y sorted version of get_all_ents()

### DIFF
--- a/sauce/entity.odin
+++ b/sauce/entity.odin
@@ -13,8 +13,9 @@ It adds too much friction.
 MAX_ENTITIES :: 2048 // increase this as needed.
 
 import "base:runtime"
-import "core:log"
 import "core:fmt"
+import "core:log"
+import "core:slice"
 
 Entity_Handle :: struct {
 	index: int,
@@ -22,13 +23,32 @@ Entity_Handle :: struct {
 	// I prefer assigning a unique ID to each entity, instead of going the generational
 	// handle route. Makes trying to debug things a bit easier if we know for a fact
 	// an entity cannot have the same ID as another one.
-	id: int,
+	id:    int,
 }
 
 zero_entity: Entity // #readonlytodo
 
 get_all_ents :: proc() -> []Entity_Handle {
 	return ctx.gs.scratch.all_entities
+}
+
+get_all_ents_y_sorted :: proc() -> []^Entity {
+	entities: [dynamic]^Entity
+
+	for &e in ctx.gs.entities[1:ctx.gs.entity_top_count + 1] {
+		if e.kind == .nil {
+			continue
+		}
+
+		append_elem(&entities, &e)
+	}
+
+	// TODO: maybe a for loop instead of lambda?
+	slice.sort_by(entities[:], proc(a: ^Entity, b: ^Entity) -> bool {
+		return a^.pos.y > b^.pos.y
+	})
+
+	return entities[:]
 }
 
 is_valid :: proc {
@@ -47,7 +67,7 @@ entity_init_core :: proc() {
 	entity_setup(&zero_entity, .nil)
 }
 
-entity_from_handle :: proc(handle: Entity_Handle) -> (entity: ^Entity, ok:bool) #optional_ok {
+entity_from_handle :: proc(handle: Entity_Handle) -> (entity: ^Entity, ok: bool) #optional_ok {
 	if handle.index <= 0 || handle.index > ctx.gs.entity_top_count {
 		return &zero_entity, false
 	}
@@ -62,13 +82,13 @@ entity_from_handle :: proc(handle: Entity_Handle) -> (entity: ^Entity, ok:bool) 
 
 entity_create :: proc(kind: Entity_Kind) -> ^Entity {
 
-	index:= -1
+	index := -1
 	if len(ctx.gs.entity_free_list) > 0 {
 		index = pop(&ctx.gs.entity_free_list)
 	}
 
 	if index == -1 {
-		assert(ctx.gs.entity_top_count+1 < MAX_ENTITIES, "ran out of entities, increase size")
+		assert(ctx.gs.entity_top_count + 1 < MAX_ENTITIES, "ran out of entities, increase size")
 		ctx.gs.entity_top_count += 1
 		index = ctx.gs.entity_top_count
 	}
@@ -88,3 +108,4 @@ entity_destroy :: proc(e: ^Entity) {
 	append(&ctx.gs.entity_free_list, e.handle.index)
 	e^ = {}
 }
+


### PR DESCRIPTION
Hi everyone! Just sharing this very basic y-sort in case someone else also needs it. If your game needs y sort, just replace the current `get_all_ents()` call in `game.odin::game_draw()` and all entities will be drawn based on their position on the y axis:

```
game_draw :: proc() {
	...
	// world
	{
		...
		for e in get_all_ents_y_sorted() {
			e.draw_proc(e^)
		}
	}
}
```
![ysort](https://github.com/user-attachments/assets/c5c8a511-f5af-46cd-ad56-e17d371e65b4)
